### PR TITLE
Clear error message when removing or placing a tile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ function AppReducer(state: AppState, action: AppAction): AppState {
       return {
         ...state,
         currentlySelectedTileIndex: undefined,
+        errorMessage: undefined,
         currentTurn: newCurrentTurn,
         playerRacks: newTilesOnRack,
       };
@@ -110,6 +111,7 @@ function AppReducer(state: AppState, action: AppAction): AppState {
 
       return {
         ...state,
+        errorMessage: undefined,
         currentTurn: currentTurnWithTileRemoved,
         playerRacks: newPlayerRacks,
       };


### PR DESCRIPTION
When an error would occur, it would never leave because I wasn't clearing them when placing or removing tiles.