### PR TITLE
Fix not accounting for cells covering gaps

### DIFF
--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -11,7 +11,7 @@ export default function validate(cells: Cells, currentTurn: CurrentTurn[]) {
   }
 
   _validateCenterCovered(cells, currentTurn);
-  _validateCurrentTurnAdjacent(currentTurn);
+  _validateCurrentTurnAdjacent(cells, currentTurn);
 }
 
 function _validateCenterCovered(cells: Cells, currentTurn: CurrentTurn[]) {
@@ -25,28 +25,39 @@ function _validateCenterCovered(cells: Cells, currentTurn: CurrentTurn[]) {
   }
 }
 
-function _validateCurrentTurnAdjacent(currentTurn: CurrentTurn[]) {
+function _validateCurrentTurnAdjacent(
+  cells: Cells,
+  currentTurn: CurrentTurn[]
+) {
   if (currentTurn.length === 1) return;
   const direction =
     currentTurn[0].column === currentTurn[1].column
       ? Direction.Vertical
       : Direction.Horizontal;
 
-  _validateNoGaps(currentTurn, direction);
   _validateRowOrColumnAllEqual(currentTurn, direction);
+  _validateNoGaps(cells, currentTurn, direction);
 }
 
-function _validateNoGaps(currentTurn: CurrentTurn[], direction: Direction) {
-  const rowOrColumnValues = currentTurn.map(
-    (cell) => cell[direction === Direction.Vertical ? "row" : "column"]
-  );
+function _validateNoGaps(
+  cells: Cells,
+  currentTurn: CurrentTurn[],
+  direction: Direction
+) {
+  const property = direction === Direction.Vertical ? "row" : "column";
+  const rowOrColumnValues = currentTurn.map((cell) => cell[property]);
   const [min, max] = [
     Math.min(...rowOrColumnValues),
     Math.max(...rowOrColumnValues),
   ];
 
   for (let i = min; i <= max; i++) {
-    if (!rowOrColumnValues.includes(i)) {
+    const tileExistsInCells =
+      direction === Direction.Vertical
+        ? cells[i][currentTurn[0].column]
+        : cells[currentTurn[0].row][i];
+
+    if (!rowOrColumnValues.includes(i) && !tileExistsInCells) {
       throw new Error("There's a gap in the cells direction");
     }
   }

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -44,8 +44,9 @@ function _validateNoGaps(
   currentTurn: CurrentTurn[],
   direction: Direction
 ) {
-  const property = direction === Direction.Vertical ? "row" : "column";
-  const rowOrColumnValues = currentTurn.map((cell) => cell[property]);
+  const rowOrColumnValues = currentTurn.map(
+    (cell) => cell[direction === Direction.Vertical ? "row" : "column"]
+  );
   const [min, max] = [
     Math.min(...rowOrColumnValues),
     Math.max(...rowOrColumnValues),


### PR DESCRIPTION
Before, the following would fail:
![Screen Shot 2021-04-25 at 1 51 54 PM](https://user-images.githubusercontent.com/37192643/116009619-8e59df80-a5cf-11eb-8913-668cbd7bad0b.png)

Now this has been accounted for in validation logic
