### PR TITLE
Block invalid tile placement & show active tiles

### DIFF
--- a/src/components/board/boardCell.tsx
+++ b/src/components/board/boardCell.tsx
@@ -22,6 +22,7 @@ export function BoardCell({
   const bonusText = bonus && firstLetterOfWords(bonus);
   const isCenter = row === 7 && col === 7;
   const isFilled = letter !== null;
+  const isClickable = isActive || !letter;
 
   return (
     <span
@@ -30,8 +31,9 @@ export function BoardCell({
         "cell--is-center": isCenter,
         "cell--is-filled": isFilled,
         "cell--is-active": isActive,
+        "cell--is-clickable": isClickable,
       })}
-      onClick={() => onClick(row, col)}
+      onClick={isClickable ? () => onClick(row, col) : undefined}
       key={col}
     >
       {letter || bonusText}

--- a/src/components/board/boardCell.tsx
+++ b/src/components/board/boardCell.tsx
@@ -7,10 +7,17 @@ interface BoardCellProps {
   row: number;
   col: number;
   onClick: (row: number, col: number) => void;
+  isActive: boolean;
   letter?: string;
 }
 
-export function BoardCell({ row, col, letter, onClick }: BoardCellProps) {
+export function BoardCell({
+  row,
+  col,
+  letter,
+  onClick,
+  isActive,
+}: BoardCellProps) {
   const bonus = BONUS_CELLS[row][col];
   const bonusText = bonus && firstLetterOfWords(bonus);
   const isCenter = row === 7 && col === 7;
@@ -22,6 +29,7 @@ export function BoardCell({ row, col, letter, onClick }: BoardCellProps) {
         [`cell--${bonus}`]: bonus,
         "cell--is-center": isCenter,
         "cell--is-filled": isFilled,
+        "cell--is-active": isActive,
       })}
       onClick={() => onClick(row, col)}
       key={col}

--- a/src/components/board/boardCells.tsx
+++ b/src/components/board/boardCells.tsx
@@ -9,10 +9,6 @@ interface BoardProps {
 }
 
 export function BoardCells({ cells, currentTurn, onCellSelect }: BoardProps) {
-  const onCellClick = (row: number, column: number) => {
-    onCellSelect(row, column);
-  };
-
   return (
     <>
       {cells.map((row, i) => (
@@ -28,7 +24,7 @@ export function BoardCells({ cells, currentTurn, onCellSelect }: BoardProps) {
                 letter={currentTurnCell ? currentTurnCell.letter : cellLetter}
                 row={i}
                 col={j}
-                onClick={onCellClick}
+                onClick={onCellSelect}
                 isActive={!!currentTurnCell}
               />
             );

--- a/src/components/board/boardCells.tsx
+++ b/src/components/board/boardCells.tsx
@@ -1,13 +1,14 @@
 import React from "react";
-import { CellsType } from "../../App";
+import { CellsType, CurrentTurn } from "../../App";
 import { BoardCell } from "./boardCell";
 
 interface BoardProps {
   cells: CellsType;
+  currentTurn: CurrentTurn[];
   onCellSelect: (row: number, col: number) => void;
 }
 
-export function BoardCells({ cells, onCellSelect }: BoardProps) {
+export function BoardCells({ cells, currentTurn, onCellSelect }: BoardProps) {
   const onCellClick = (row: number, column: number) => {
     onCellSelect(row, column);
   };
@@ -17,13 +18,18 @@ export function BoardCells({ cells, onCellSelect }: BoardProps) {
       {cells.map((row, i) => (
         <section className="row" key={i}>
           {row.map((cellLetter, j) => {
+            const currentTurnCell = currentTurn.find(
+              (turn) => turn.row === i && turn.column === j
+            );
+
             return (
               <BoardCell
                 key={j}
-                letter={cellLetter}
+                letter={currentTurnCell ? currentTurnCell.letter : cellLetter}
                 row={i}
                 col={j}
                 onClick={onCellClick}
+                isActive={!!currentTurnCell}
               />
             );
           })}

--- a/src/components/board/index.scss
+++ b/src/components/board/index.scss
@@ -56,6 +56,7 @@
   }
 
   &--is-active {
+    box-shadow: 0 0 10px #fecb02;
     border: 3px solid $highlight-color;
   }
 

--- a/src/components/board/index.scss
+++ b/src/components/board/index.scss
@@ -14,7 +14,6 @@
 
 .cell {
   background-color: #2e4f62;
-  cursor: pointer;
   font-size: 10px;
   height: 45px;
   width: 45px;
@@ -29,6 +28,7 @@
   margin: 2px;
   border-top: $cell-border-top;
   border-left: $cell-border-left;
+  cursor: default;
 
   &--double-letter {
     background: #3baaf1;
@@ -60,7 +60,10 @@
     border: 3px solid $highlight-color;
   }
 
-  &:hover {
-    opacity: 0.9;
+  &--is-clickable {
+    &:hover {
+      opacity: 0.75;
+      cursor: pointer;
+    }
   }
 }

--- a/src/components/board/index.scss
+++ b/src/components/board/index.scss
@@ -56,7 +56,7 @@
   }
 
   &--is-active {
-    border: 3px solid red;
+    border: 3px solid $highlight-color;
   }
 
   &:hover {

--- a/src/components/board/index.scss
+++ b/src/components/board/index.scss
@@ -18,7 +18,6 @@
   font-size: 10px;
   height: 45px;
   width: 45px;
-  transition: all 0.25s ease-in-out;
   text-transform: uppercase;
   display: flex;
   justify-content: center;
@@ -54,6 +53,10 @@
   &--is-filled {
     background: $default-tile-color;
     color: $cell-background-color;
+  }
+
+  &--is-active {
+    border: 3px solid red;
   }
 
   &:hover {

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -46,3 +46,6 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+* {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
![Screen Shot 2021-04-25 at 1 55 46 PM](https://user-images.githubusercontent.com/37192643/116009553-3b802800-a5cf-11eb-8536-44ef30a2585d.png)

- Fixes a bug where players were able to add a tile to a location that already had a tile
- Blocks clicks on existing cells
- Add `isActive` style to cells to show which cells are yours
- Changes cursor to pointer only on clickable cells and to default on non-clickable cells